### PR TITLE
Add node function to get peer data

### DIFF
--- a/node/Node.hpp
+++ b/node/Node.hpp
@@ -92,6 +92,7 @@ public:
 	uint64_t address() const;
 	void status(ZT_NodeStatus *status) const;
 	ZT_PeerList *peers() const;
+	ZT_Peer *peer(void *tptr,uint64_t nwid,uint64_t mac) const;
 	ZT_VirtualNetworkConfig *networkConfig(uint64_t nwid) const;
 	ZT_VirtualNetworkList *networks() const;
 	void freeQueryResult(void *qr);


### PR DESCRIPTION
Step 1 for retrieving route information for players in your DevX game session. Mostly copied from the `Node::peers()` function.